### PR TITLE
Hotfix Personal Data

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -46,7 +46,7 @@ function Footer({ staticContent }: { staticContent: IFooterContent }): JSX.Eleme
 						<h6>{contactsText}</h6>
 						<div>
 							<p>Patrick Pavliuchik,</p>
-							<a href='tel:04917782934'>+49 17782934</a>
+							<a href='tel:+4915679396206'>+49 (0) 15679 396206</a>
 							<a href='mailto:patrick@pavliuchik.com'>patrick@pavliuchik.com</a>
 						</div>
 					</div>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -63,7 +63,6 @@ function Footer({ staticContent }: { staticContent: IFooterContent }): JSX.Eleme
 								targetId='aboutSection'
 								style='normalSmall'
 							/>
-							<NavigationButton text={resumeText} targetId='resume' style='normalSmall' />
 							<NavigationButton
 								text='LinkedIn'
 								style='normalSmall'

--- a/src/components/ImprintPage/ImprintPage.tsx
+++ b/src/components/ImprintPage/ImprintPage.tsx
@@ -20,7 +20,7 @@ function ImprintPage() {
 				</p>
 				<h2>{currentLanguage === 'de' ? 'Kontakt' : 'Contact'}</h2>
 				<p>
-					{currentLanguage === 'de' ? 'Telefon' : 'Phone'}: +49 (0) 17794184354
+					{currentLanguage === 'de' ? 'Telefon' : 'Phone'}: +49 (0) 15679 396206
 					<br />
 					E-Mail: patrick@pavliuchik.com
 				</p>

--- a/src/components/PrivacyPage/privacyContent.tsx
+++ b/src/components/PrivacyPage/privacyContent.tsx
@@ -138,14 +138,14 @@ const content = {
 				<p>
 					Patrick Pavliuchik
 					<br />
-					ADRESSE
+					K&ouml;rtingstr. 61c
 					<br />
-					PLZ
+					12107 Berlin
 				</p>
 				<p>
-					Telefon: 04923854
+					Telefon: +49 (0) 15679 396206
 					<br />
-					E-Mail: fkodfok@jdsjf.com
+					E-Mail: patrick@pavliuchik.com
 				</p>
 				<p>
 					Verantwortliche Stelle ist die nat&uuml;rliche oder juristische Person, die
@@ -635,14 +635,14 @@ const content = {
 				<p>
 					Patrick Pavliuchik
 					<br />
-					ADDRESS
+					K&ouml;rtingstr. 61c
 					<br />
-					ZIP CODE
+					12107 Berlin
 				</p>
 				<p>
-					Phone: 04923854
+					Phone: +49 (0) 15679 396206
 					<br />
-					Email: fkodfok@jdsjf.com
+					Email: patrick@pavliuchik.com
 				</p>
 				<p>
 					The responsible entity is the natural or legal person who alone or jointly with


### PR DESCRIPTION
# Hotfix Personal Data

Refactored the footer section by removing the resume download button, as the resume download feature is no longer available. Additionally, replaced dummy address and phone number data with current contact information to enable users to reach me directly.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
